### PR TITLE
Remove mysql-python

### DIFF
--- a/index.md
+++ b/index.md
@@ -80,7 +80,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [go-sql-driver](https://github.com/go-sql-driver/mysql) - a lightweight and fast MySQL-Driver for Go's (golang) database/sql package.
 - [libAttachSQL](http://libattachsql.org) - libAttachSQL is a lightweight, non-blocking C API for MySQL servers.
 - [MariaDB Java Client](https://mariadb.com/kb/en/mariadb/mariadb-connector-j/) - LGPL-licensed MariaDB Client Library for Java Applications.
-- [MySQL-Python](http://sourceforge.net/projects/mysql-python/) - MySQL database connector for Python programming.
 - [node-mysql](https://github.com/felixge/node-mysql) - A pure Nodejs Javascript client implementing the MySQL protocol.
 - [PHP mysqlnd](https://dev.mysql.com/downloads/connector/php-mysqlnd/) - MySQL native driver for MySQL, deprecating older libmysql based driver.
 


### PR DESCRIPTION
https://sourceforge.net/projects/mysql-python/ links to:
https://github.com/farcepest/MySQLdb1 and there it states:
"This is the legacy (1.x) version of MySQLdb. While it is
still being maintained, there will not be a lot of new
feature development."

I don't think it belongs on this list.

Related issue: https://github.com/shlomi-noach/awesome-mysql/issues/44
