### PR TITLE
Remove WebScaleSQL.

### DIFF
--- a/index.md
+++ b/index.md
@@ -167,7 +167,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [MariaDB](https://github.com/MariaDB/server) - Community developed fork of MySQL server.
 - [MySQL Server & MySQL Cluster](https://github.com/mysql/mysql-server) - Official Oracle's MySQL server & MySQL Cluster distribution.
 - [Percona Server](https://launchpad.net/percona-server) - An enhanced, drop-in MySQL replacement.
-- [WebScaleSQL](https://github.com/webscalesql/webscalesql-5.6) - WebScaleSQL, Version 5.6, based upon the MySQL-5.6 community releases.
 
 ## Sharding
 


### PR DESCRIPTION
WebScaleSQL is abandonware per
http://webscalesql.org/blog/2016/12/02/Moving-Forward.html and
https://en.wikipedia.org/wiki/MySQL#Abandoned