### PR TITLE
Replaced MySQL-Sandbox with dbdeployer

### DIFF
--- a/index.md
+++ b/index.md
@@ -95,7 +95,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *MySQL deployment tools*
 
 - [MySQL Docker](https://hub.docker.com/_/mysql/) - Official Docker images.
-- [MySQL Sandbox](http://mysqlsandbox.net/) - a tool that installs one or more MySQL servers within seconds, easily, securely, and with full control.
+- [dbdeployer](https://www.dbdeployer.com) - A tool that installs one or more MySQL servers within seconds, easily, securely, and with full control.
 
 
 ## Development


### PR DESCRIPTION
MySQL-Sandbox is going to be abandoned soon, and can be replaced with dbdeployer, which is now able to run all MySQL-Sandbox features, and much more. 
Note: I maintain both projects, and I don't think that MySQL-Sandbox has a future.