### PR TITLE
Update MyDumper link

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 *Backup/restore/recovery tools*
 
-- [MyDumper](https://launchpad.net/mydumper) - Logical, parallel backup/dumper tool for MySQL
+- [MyDumper](https://github.com/maxbube/mydumper) - Logical, parallel backup/dumper tool for MySQL
 - [MySQLDumper](http://www.mysqldumper.net/) - open-source web based backup tool - useful for shared webhosting
 - [Percona Xtrabackup](http://www.percona.com/doc/percona-xtrabackup) - an open-source hot backup utility for MySQL - based servers that doesn’t lock your database during the backup.
 


### PR DESCRIPTION
The Launchpad site indicates it has relocated to GitHub, and there are newer releases available from there.