### PR TITLE
Remove DataGrip: non-free and not open source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *GUI frontends & applications*
 
 - [Adminer](https://www.adminer.org/) - Database management in a single PHP file.
-- [DataGrip](https://www.jetbrains.com/datagrip/) - Cross-Platform IDE for Databases & SQL by JetBrains.
 - [HeidiSQL](http://www.heidisql.com/) - MySQL GUI frontend for Windows.
 - [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
 - [MySQL Shell](https://dev.mysql.com/downloads/shell/) - Advanced client and code editor for MySQL that supports development and administration for the MySQL Server and MySQL InnoDB cluster (AdminAPI) with an interactive JavaScript, Python, or SQL interface.


### PR DESCRIPTION
I couldn't find a free and open-source version of the DataGrip IDE, so it doesn't meet requirements for this list.