### PR TITLE
add dumpling and dm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [MyDumper](https://github.com/maxbube/mydumper) - Logical, parallel backup/dumper tool for MySQL
 - [MySQLDumper](http://www.mysqldumper.net/) - open-source web based backup tool - useful for shared webhosting
 - [Percona Xtrabackup](http://www.percona.com/doc/percona-xtrabackup) - an open-source hot backup utility for MySQL - based servers that doesn’t lock your database during the backup.
+- [Dumpling](https://github.com/pingcap/dumpling) - Logical, parallel backup/dumper tool for MySQL/TiDB written in GoLang - support csv format output and integrated as library
 
 ## Benchmarking
 
@@ -66,6 +67,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 - [Kingbus](https://github.com/flike/kingbus) - A distributed MySQL binlog storage system built on Raft
 - [mysql-ripple](https://github.com/google/mysql-ripple) - Ripple, a server that can serve as a middleman in MySQL replication
+- [TiDB-DM](https://github.com/pingcap/dm) - A High-Availability data migration platform which supports migrating data from MySQL/MariaDB to TiDB and merging shard tables
 
 ## ChatOps
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 *Backup/restore/recovery tools*
 
+- [Dumpling](https://github.com/pingcap/dumpling) - Logical, parallel backup/dumper tool for MySQL/TiDB written in GoLang - support csv format output and integrated as library
 - [MyDumper](https://github.com/maxbube/mydumper) - Logical, parallel backup/dumper tool for MySQL
 - [MySQLDumper](http://www.mysqldumper.net/) - open-source web based backup tool - useful for shared webhosting
 - [Percona Xtrabackup](http://www.percona.com/doc/percona-xtrabackup) - an open-source hot backup utility for MySQL - based servers that doesn’t lock your database during the backup.
-- [Dumpling](https://github.com/pingcap/dumpling) - Logical, parallel backup/dumper tool for MySQL/TiDB written in GoLang - support csv format output and integrated as library
 
 ## Benchmarking
 
@@ -65,9 +65,9 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 ## Binlog-Replication
 
+- [DM](https://github.com/pingcap/dm) - A High-Availability data migration platform which supports migrating data from MySQL/MariaDB to TiDB and merging shard tables
 - [Kingbus](https://github.com/flike/kingbus) - A distributed MySQL binlog storage system built on Raft
 - [mysql-ripple](https://github.com/google/mysql-ripple) - Ripple, a server that can serve as a middleman in MySQL replication
-- [TiDB-DM](https://github.com/pingcap/dm) - A High-Availability data migration platform which supports migrating data from MySQL/MariaDB to TiDB and merging shard tables
 
 ## ChatOps
 


### PR DESCRIPTION
[Dumpling](https://github.com/pingcap/dumpling) is a toolbox written in Go to export MySQL/MariaDB/TiDB to csv/sql format files.
It will support different storage types and more databases in the future and can be easily integrated in other Go-based programs.

[DM](https://github.com/pingcap/dumpling) is a platform written in Go to support migrate MySQL/MariaDB to TiDB. It has some valuable features:
1. support full/incremental/all mode of migration for MySQL/MariaDB.
2. support merging shard tables from different MySQL instances
3. high Availability support