### PR TITLE
Remove `openark-kit` as long since unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [gh-ost](https://github.com/github/gh-ost/) - GitHub's online schema migration for MySQL.
 - [go-mysql](https://github.com/siddontang/go-mysql) - A pure go library to handle MySQL network protocol and replication.
 - [MySQL Utilities](https://dev.mysql.com/downloads/utilities/) - a collection of command-line utilities, written in Python, that are used for maintaining and administering MySQL servers, either individually, or within Replication hierarchies.
-- [openark kit](http://code.openark.org/forge/openark-kit) - a set of utilities that solve everyday maintenance tasks, which may be complicated or time consuming to do by hand, written in Python.
 - [Percona Toolkit](https://www.percona.com/software/mysql-tools/percona-toolkit) - a collection of advanced command-line tools to perform a variety of MySQL server and system tasks that are too difficult or complex to perform manually.
 - [UnDROP](https://bitbucket.org/Marc-T/undrop-for-innodb) - a tool to recover data from dropped or corrupted InnoDB tables.
 


### PR DESCRIPTION
`openark-kit` has not been in maintenance since about 8 years now, with no expectation to maintain it (I'm the author). It's likely outdated and I'm not sure who might be using it.