### PR TITLE
Add Wireshark

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [Percona Monitoring and Management](https://www.percona.com/doc/percona-monitoring-and-management/index.html) - An open-source platform for managing and monitoring MySQL performance.
 - [Prometheus](https://prometheus.io/)/[mysqld_exporter](https://github.com/prometheus/mysqld_exporter) - Time series database for real-time monitoring and alerting.
 - [pstop](https://github.com/sjmudd/ps-top) - a top-like program for MySQL, collecting, aggregating and displaying information from performance_schema.
+- [Wireshark](https://gitlab.com/wireshark/wireshark/) - a protocol analyzer that can decode the MySQL protocol.
+
 ## Backup
 
 *Backup/restore/recovery tools*


### PR DESCRIPTION
Wireshark is GPLv2 licensed.

For the MySQL specific bit: https://gitlab.com/wireshark/wireshark/-/blob/master/epan/dissectors/packet-mysql.c

Wireshark is on GitLab, but has a read-only mirror on https://github.com/wireshark/wireshark