### PR TITLE
Add mariadb-containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 - [dbdeployer](https://github.com/datacharmer/dbdeployer) (archived) - A tool that installs one or more MySQL servers within seconds, easily, securely, and with full control.
 - [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) - A Java launcher to run MariaDB without installation or external dependencies.
+- [mariadb-container](https://github.com/sclorg/mariadb-container) - MariaDB Dockerfiles with a focus on OpenShift usage, but suitable for general use.
 - [MySQL Docker](https://hub.docker.com/_/mysql/) - Official Docker images.
 
 


### PR DESCRIPTION
The license is Apache 2.

It's been around for 6 years and it's actively maintained.

Downside: it doesn't include the most recent LTS version (11.4) or later versions.

Also please check the alphabetical order.