### PR TITLE
Add Swoof CLI importer to Toolkits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [go-mysql](https://github.com/go-mysql-org/go-mysql) - A pure go library to handle MySQL network protocol and replication.
 - [MySQL Utilities](https://github.com/mysql/mysql-utilities) (deprecated) - a collection of command-line utilities, written in Python, that are used for maintaining and administering MySQL servers, either individually, or within Replication hierarchies.
 - [Percona Toolkit](https://github.com/percona/percona-toolkit) - a collection of advanced command-line tools to perform a variety of MySQL server and system tasks that are too difficult or complex to perform manually.
+- [Swoof](https://github.com/StirlingMarketingGroup/swoof) - Ultra fast MySQL table importer that stages swaps through temporary tables and supports file/clipboard targets.
 - [UnDROP](https://github.com/twindb/undrop-for-innodb) - a tool to recover data from dropped or corrupted InnoDB tables.
 
 # Resources


### PR DESCRIPTION
## Summary
- add Swoof to the Toolkits section of the awesome-mysql list
- highlight its temp-table swap safety and support for file/clipboard destinations

## Testing
- n/a (documentation only)
