### PR TITLE
Add MCP to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
     - [Development](#development)
     - [GUI](#gui)
     - [HA](#ha)
+    - [MCP](#mcp)
     - [Proxy](#proxy)
     - [Replication](#replication)
     - [Schema](#schema)


### PR DESCRIPTION
With #150 I added an MCP section with one item. This PR adds "MCP" to the table of contents, which I forgot to do before.


