### PR TITLE
docs: add MySQL MCP Server to MCP section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 ## MCP
 
 - [MCP MariaDB Server](https://github.com/MariaDB/mcp) - the official MariaDB MCP server.
+- [MySQL MCP Server](https://github.com/askdba/mysql-mcp-server) - Advanced MCP server exposing MySQL via the Model Context Protocol
 
 ## Proxy
 


### PR DESCRIPTION
Adding MySQL MCP Server to the list of open source MCP servers. 