### PR TITLE
Mark archived projects: Orchestrator, data-diff, sys, and UnDROP

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *Add-on schemas*
 
 - [common_schema](https://github.com/shlomi-noach/common_schema) - DBA's framework for MySQL, providing a function library, views library and QueryScript interpreter.
-- [sys](https://github.com/mysql/mysql-sys) (archived) - A collection of views, functions and procedures to help MySQL administrators get insight in to MySQL Database usage. See [https://dev.mysql.com/doc/refman/8.4/en/sys-schema.html](https://dev.mysql.com/doc/refman/8.4/en/sys-schema.html)
+- [sys](https://github.com/mysql/mysql-sys) (archived) - A collection of views, functions and procedures to help MySQL administrators get insight in to MySQL Database usage. See [sys schema docs](https://dev.mysql.com/doc/refman/8.4/en/sys-schema.html)
 
 
 ## Security


### PR DESCRIPTION
   These four projects are archived on GitHub but were not previously marked
   as such in the README.
