### PR TITLE
Fix broken link, add check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [MySQL Connector/Node.js](https://github.com/mysql/mysql-connector-nodejs) - Official Node.js driver for MySQL.
 - [MySQL Connector/Python](https://github.com/mysql/mysql-connector-python) - a standardized database driver for Python platforms and development.
 - [mysqlclient-python](https://github.com/PyMySQL/mysqlclient) - MySQL database connector for Python.
-- [node-mysql](https://github.com/mysqljs/node) - A pure Nodejs Javascript client implementing the MySQL protocol.
+- [node-mysql](https://github.com/mysqljs/mysql) - A pure Nodejs Javascript client implementing the MySQL protocol.
 - [PHP mysqlnd](https://www.php.net/manual/en/book.mysqlnd.php) - MySQL native driver for PHP.
 - [PyMySQL](https://github.com/PyMySQL/PyMySQL) - MySQL database connector for Python.
 - [Ruby Mysql2 gem](https://github.com/brianmario/mysql2) - MySQL driver for Ruby and Rails projects.

--- a/scripts/check_archived.py
+++ b/scripts/check_archived.py
@@ -1,0 +1,27 @@
+#!/bin/python
+import os
+import re
+import requests
+
+GHRE = re.compile(r'\(https://github.com/(.*?)\)')
+
+token = os.environ["GITHUB_TOKEN"]
+headers= {"Authorization": f"Bearer {token}"}
+
+with open('README.md', 'r') as fh:
+    for line in fh.readlines():
+        if m := GHRE.search(line):
+            repo = m.group(1)
+            if repo.count('/') != 1:
+                # Not a project, probably a deeper path
+                continue
+            apiurl = f'https://api.github.com/repos/{repo}'
+            try:
+                r = requests.get(apiurl, headers=headers)
+                r.raise_for_status()
+                data = r.json()
+                if data['archived']:
+                    print(f'{repo} is archived\n{line}\n')
+            except Exception as e:
+                print(f'https://github.com/{repo}: failed to retrieve status: {e}\n')
+


### PR DESCRIPTION
The script checks
- GitHub repos that have been deleted or renamed
- GitHub urls that are archived

```
export GITHUB_TOKEN=...
./scripts/check_archived.py
```

This now just prints the output, but it chould check if the line has `deprecated` or `archived` and then be made in a GitHub action

<!--
Thanks for your contribution.

See CONTRIBUTING.md for the full contribution guidelines.
-->


