### PR TITLE
remove mysql docker images listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *MySQL deployment tools*
 
 - [MariaDB4j](https://github.com/MariaDB4j/MariaDB4j) - A Java launcher to run MariaDB without installation or external dependencies.
-- [MySQL Docker](https://hub.docker.com/_/mysql/) - Official Docker images.
 
 
 ## Development


### PR DESCRIPTION
See discussion in https://github.com/shlomi-noach/awesome-mysql/issues/164

Justification: `awesome-mysql` is meant to link to projects in the MySQL ecosystem. It is beyond its scope to also list every docker image out there. This is the duty of the distinct projects. 