### PR TITLE
Add myanon to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *Tools that prevents leaking of sensitive data from database (encryption, masking and tokenization, honey-pots, etc)*
 
 - [Acra](https://github.com/cossacklabs/acra) - SQL database protection suite: strong selective encryption, SQL injections prevention, intrusion detection system.
+- [myanon](https://github.com/ppomes/myanon) - Streaming anonymizer for MySQL dump files, reading mysqldump output from stdin and writing anonymized data to stdout. Supports deterministic hashing, fixed values, JSON field anonymization, and Python extensions.
 - [myldapsync](https://github.com/6eh01der/myldapsync) - Synchronize MySQL or MariaDB users with users in an LDAP directory.
 
 ## Server


### PR DESCRIPTION
[myanon](https://github.com/ppomes/myanon) is a streaming anonymizer for MySQL dump files. It reads mysqldump output from stdin and writes anonymized data to stdout.

Key features:
- Deterministic hashing (HMAC-SHA256) preserving referential integrity
- Built-in rules: texthash, emailhash, inthash, fixed values, substrings
- JSON field anonymization
- Python extensions (e.g., Faker)
- Written in C, single binary, also available as Docker image

Website: https://myanon.io