### PR TITLE
Add sql-splitter to Toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [go-mysql](https://github.com/go-mysql-org/go-mysql) - A pure go library to handle MySQL network protocol and replication.
 - [MySQL Utilities](https://github.com/mysql/mysql-utilities) (deprecated) - a collection of command-line utilities, written in Python, that are used for maintaining and administering MySQL servers, either individually, or within Replication hierarchies.
 - [Percona Toolkit](https://github.com/percona/percona-toolkit) - a collection of advanced command-line tools to perform a variety of MySQL server and system tasks that are too difficult or complex to perform manually.
+- [sql-splitter](https://github.com/HelgeSverre/sql-splitter) - High-performance CLI for splitting, merging, converting, validating, and sampling mysqldump files.
 - [Swoof](https://github.com/StirlingMarketingGroup/swoof) - Ultra fast MySQL table importer that stages swaps through temporary tables and supports file/clipboard targets.
 - [UnDROP](https://github.com/twindb/undrop-for-innodb) (archived) - a tool to recover data from dropped or corrupted InnoDB tables.
 


### PR DESCRIPTION
Adds [sql-splitter](https://github.com/HelgeSverre/sql-splitter) to the **Toolkits** section.

sql-splitter is a high-performance CLI (written in Rust) for working with mysqldump files:

- **Split** large dumps into per-table files
- **Merge** split files back into a single dump
- **Convert** between MySQL, PostgreSQL, SQLite, and MSSQL
- **Validate** syntax, encoding, and referential integrity
- **Sample** with FK-aware subsetting for realistic dev/test data
- **Analyze** table sizes, row counts, and schema information

Streaming architecture handles 10GB+ dumps with constant memory usage.

Website: https://www.sql-splitter.dev