### PR TITLE
Proxies: Remove mysql-proxy, add sql-tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [pstop](https://github.com/sjmudd/ps-top) - a top-like program for MySQL, collecting, aggregating and displaying information from performance_schema.
 - [Wireshark](https://gitlab.com/wireshark/wireshark/) - a protocol analyzer that can decode the MySQL protocol.
 - [Dolphie](https://github.com/charles-001/dolphie) - a modern terminal tool for real-time analytics into MySQL/MariaDB & ProxySQL
+- [sql-tap](https://github.com/mickamy/sql-tap) - Real-time SQL traffic viewer.
 
 ## Backup
 
@@ -167,7 +168,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 *Proxies to MySQL*
 
-- [MySQL Proxy](https://github.com/mysql/mysql-proxy) (deprecated) - A simple program that sits between your client and MySQL server(s) that can monitor, analyze or transform their communication.
 - [MySQL Router](https://dev.mysql.com/doc/mysql-router/en/) - MySQL Router is part of InnoDB cluster, and is a lightweight middleware that provides transparent routing between your application and back-end MySQL Servers.
 - [ProxySQL](https://github.com/sysown/proxysql) - High performance proxy for MySQL.
 


### PR DESCRIPTION
<!--
Thanks for your contribution.

See CONTRIBUTING.md for the full contribution guidelines.
-->

- Add https://github.com/mickamy/sql-tap (MIT License) by @mickamy
- Remove mysql-proxy

- [x] Project is under [a free and open source license](https://www.gnu.org/licenses/license-list.html)
- [x] Project is related to MySQL
- [x] Project is GA (production ready, not abandoned/discontinued)
- [x] Link points to the GitHub/Gitlab repository when available.

I put this under "Proxy", but it also fits "Analysis"