### PR TITLE
Add SQL Syntax Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 - [Database Systems Lecture Notes](http://spots.augusta.edu/caubert/db/ln/) - lecture notes on Database Systems (available in pdf, html, odt and markdown) including a Chapter on SQL that covers basic set-up, exercises and problems.
 - [SQL-exercise](https://github.com/XD-DENG/SQL-exercise) - contains several SQL exercises, including the schema description figure, SQL code to build schema, questions and solutions in SQL. Based on wikibook [SQL Exercises](https://en.wikibooks.org/wiki/SQL_Exercises).
+- [SQL Syntax Cheat Sheet](https://github.com/mergisi/sql-syntax-cheat-sheet) - Comprehensive reference covering DDL, DML, JOINs, subqueries, window functions, CTEs, database-specific syntax (including MySQL), and performance tips.
 
 ## Incubating
 


### PR DESCRIPTION
Adds [SQL Syntax Cheat Sheet](https://github.com/mergisi/sql-syntax-cheat-sheet) to the e-books section.

A comprehensive SQL syntax reference with 20 sections covering DDL, DML, JOINs, subqueries, window functions, CTEs, database-specific syntax (including MySQL full-text search, ON DUPLICATE KEY), performance tips, and common mistakes.