### PR TITLE
add cover_me

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [Skeema](https://github.com/skeema/skeema) - Declarative pure-SQL schema management system for MySQL and MariaDB, with support for sharding and external online schema change tools
 - [SQLE](https://github.com/actiontech/sqle/blob/main/README_en.md) - SQLE is a SQL audit platform for DBA or developer
 - [Test database](https://github.com/datacharmer/test_db) - A sample MySQL database with an integrated test suite, used to test applications and servers
+- [cover_me](https://github.com/verizonconnect/database-development) - code coverage tool for mysql stored procedures and functions
 
 ## GUI
 


### PR DESCRIPTION
Native code coverage tooling for PL/pgSQL that integrates cleanly into standard CI/CD pipelines is limited. cover_me is an open-source Python tool developed at Verizon Connect that generates OpenCover XML reports for PostgreSQL database code. It instruments functions to use RAISE WARNING to track execution, ensuring that coverage hits survive transaction rollbacks during standard TAP-based unit testing (e.g., using pgTAP).

<!--
Thanks for your contribution.

See CONTRIBUTING.md for the full contribution guidelines.
-->

- [x] Project is under [a free and open source license](https://www.gnu.org/licenses/license-list.html)
- [x] Project is related to MySQL
- [x] Project is GA (production ready, not abandoned/discontinued)
- [x] Link points to the GitHub/Gitlab repository when available.
