### PR TITLE
Add Bytebase to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 *Tools to support MySQL-related development*
 
+- [Bytebase](https://github.com/bytebase/bytebase) - database DevOps and CI/CD for teams, with SQL review, schema migration, and role-based access control.
 - [Flywaydb](https://github.com/flyway/flyway) - Database migrations; Evolve your database schema easily and reliably across all your instances
 - [dbsafe](https://github.com/nethalo/dbsafe) - Pre-execution safety analysis for MySQL DDL/DML operations
 - [Liquibase](https://github.com/liquibase/liquibase) - Source control for your database


### PR DESCRIPTION
Add [Bytebase](https://github.com/bytebase/bytebase) to the Development section, alongside Flyway, Liquibase, Skeema, and other schema migration / database DevOps tools.

Bytebase is an open-source database DevOps and CI/CD platform for teams. It provides SQL review, schema migration management, role-based access control, and supports MySQL, PostgreSQL, and more.

- 12k+ GitHub stars
- Actively maintained with regular releases
- Used by teams for MySQL schema change management with built-in SQL lint rules

Placed alphabetically in the Development section.