### PR TITLE
Add ReliaDB EXPLAIN Analyzer to Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [MySQLTuner-perl](https://github.com/major/MySQLTuner-perl) - A script that allows you to review a MySQL installation quickly and make adjustments to increase performance and stability.
 - [Prometheus](https://github.com/prometheus/prometheus)/[mysqld_exporter](https://github.com/prometheus/mysqld_exporter) - Time series database for real-time monitoring and alerting.
 - [pstop](https://github.com/sjmudd/ps-top) - a top-like program for MySQL, collecting, aggregating and displaying information from performance_schema.
-- [ReliaDB EXPLAIN Analyzer](https://github.com/Mughees52/mysql-explain-analyzer) - a browser-based MySQL and MariaDB EXPLAIN visualizer with 49 detection rules, index advisor, query rewrite suggestions, and impact simulation. Supports EXPLAIN ANALYZE, FORMAT=JSON, and MariaDB ANALYZE. 100% client-side.
+- [ReliaDB EXPLAIN Analyzer](https://github.com/Mughees52/mysql-explain-analyzer) - a browser-based MySQL and MariaDB EXPLAIN visualizer with issue detection, index recommendations, and query rewrites. 100% client-side.
 - [Wireshark](https://gitlab.com/wireshark/wireshark/) - a protocol analyzer that can decode the MySQL protocol.
 - [Dolphie](https://github.com/charles-001/dolphie) - a modern terminal tool for real-time analytics into MySQL/MariaDB & ProxySQL
 - [sql-tap](https://github.com/mickamy/sql-tap) - Real-time SQL traffic viewer.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [MySQLTuner-perl](https://github.com/major/MySQLTuner-perl) - A script that allows you to review a MySQL installation quickly and make adjustments to increase performance and stability.
 - [Prometheus](https://github.com/prometheus/prometheus)/[mysqld_exporter](https://github.com/prometheus/mysqld_exporter) - Time series database for real-time monitoring and alerting.
 - [pstop](https://github.com/sjmudd/ps-top) - a top-like program for MySQL, collecting, aggregating and displaying information from performance_schema.
+- [ReliaDB EXPLAIN Analyzer](https://github.com/Mughees52/mysql-explain-analyzer) - a browser-based MySQL and MariaDB EXPLAIN visualizer with 49 detection rules, index advisor, query rewrite suggestions, and impact simulation. Supports EXPLAIN ANALYZE, FORMAT=JSON, and MariaDB ANALYZE. 100% client-side.
 - [Wireshark](https://gitlab.com/wireshark/wireshark/) - a protocol analyzer that can decode the MySQL protocol.
 - [Dolphie](https://github.com/charles-001/dolphie) - a modern terminal tool for real-time analytics into MySQL/MariaDB & ProxySQL
 - [sql-tap](https://github.com/mickamy/sql-tap) - Real-time SQL traffic viewer.


### PR DESCRIPTION
  A free, browser-based MySQL and MariaDB EXPLAIN visualizer with:
  - 49 detection rules (critical, warning, info, good)                                                                  
  - Query-aware index advisor with composite covering indexes                                                           
  - 7 query rewrite generators                               
  - Index impact simulator                                                                                              
  - Supports MySQL EXPLAIN ANALYZE, FORMAT=JSON, and MariaDB ANALYZE                                                  
  - 100% client-side — no backend, no data sent anywhere            
                                                                                                                        
  Live: https://reliadb.com/tools/explain/
  Repo: https://github.com/Mughees52/mysql-explain-analyzer                                                             
  License: MIT  
