### PR TITLE
Add LibreDB Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [DBeaver](https://github.com/dbeaver/dbeaver/) - A cross-platform SQL and NoSQL database client.
 - [HeidiSQL](https://github.com/HeidiSQL/HeidiSQL) - MySQL GUI frontend for Windows.
 - [ILLA Cloud](https://github.com/illacloud/illa-builder) - Low-code internal tool builder integrated with Mysql, can be used as GUI for Mysql. 
+- [LibreDB Studio](https://github.com/libredb/libredb-studio) - Browser-based SQL IDE for MySQL and nine other engines, deployed as a container or Helm chart next to the database.
 - [mycli](https://github.com/dbcli/mycli) - A Terminal Client for MySQL with AutoCompletion and Syntax Highlighting.
 - [MySQL Shell](https://github.com/mysql/mysql-shell/) - Advanced client and code editor for MySQL that supports development and administration for the MySQL Server and MySQL InnoDB cluster (AdminAPI) with an interactive JavaScript, Python, or SQL interface.
 - [MySQL Workbench](https://github.com/mysql/mysql-workbench) - provides DBAs and developers an integrated tools environment for database design & modeling; SQL devleopment; database administration.


### PR DESCRIPTION
Adds LibreDB Studio to the GUI section, in alphabetical order.

- Repo: https://github.com/libredb/libredb-studio
- License: MIT
- Install: `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest`

A browser-based SQL IDE built to run inside the same network as the database instead of on a laptop. For MySQL it covers the schema explorer, EXPLAIN plans, transactions, query cancellation via `KILL QUERY`, SSL/TLS and SSH tunnels, plus ER diagrams and schema diff with generated migration SQL.
