### PR TITLE
Add Syncle to Replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *Replication related software*
 
 * [data-diff](https://github.com/datafold/data-diff) (archived) - Command-line tool and Python library to efficiently diff rows across two different databases.
+* [Syncle](https://github.com/osmanahmadxai/SYNCLE) - Syncs rows between MySQL and PostgreSQL, SQLite, MongoDB or Redis, by backfill, cursor polling, or reading the binlog
 
 
 ## Schema

--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 *Replication related software*
 
 * [data-diff](https://github.com/datafold/data-diff) (archived) - Command-line tool and Python library to efficiently diff rows across two different databases.
-* [Syncle](https://github.com/osmanahmadxai/SYNCLE) - Syncs rows between MySQL and PostgreSQL, SQLite, MongoDB or Redis, by backfill, cursor polling, or reading the binlog
 
 
 ## Schema
@@ -248,4 +247,5 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 
 Projects that are known to be non-production and yet have either traction or substance that warrants exposure.
 
+- [Syncle](https://github.com/osmanahmadxai/SYNCLE) - Syncs rows between MySQL and PostgreSQL, SQLite, MongoDB or Redis, by backfill, cursor polling, or reading the binlog
 - [VillageSQL](https://github.com/villagesql/villagesql-server) - A drop-in replacement for MySQL with extensions for the agentic AI era.


### PR DESCRIPTION
Adds [Syncle](https://github.com/osmanahmadxai/SYNCLE) to **Replication**.

It syncs rows between MySQL/MariaDB and PostgreSQL, SQLite, MongoDB or Redis, in either direction. For a MySQL source it reads the binlog directly; it can also run a one-off backfill or poll a cursor instead. Writes are idempotent upserts keyed by the columns you choose, destination tables are created when missing with types translated across engines, and interrupted jobs resume from their cursor.

Against your criteria, honestly:

- **Free and open source** — MIT.
- **Active in a production environment** — yes. It was written to solve a specific problem and runs in one: a biometric attendance device whose data was being lost in transit to a remote server. Syncle runs locally beside it and syncs that data reliably to the remote database. Debezium and the platform-scale tools were far more machinery than that job needed, which is why it exists.
- **Reasonably GA quality** — tagged releases (v1.2.0), a test suite, a published image, and documentation for every command and endpoint.
- **Not abandoned** — actively developed.
- **Reasonably recognized and adopted** — this is the one it does not yet clear. It is young and has few stars.

I have put it under Replication because it is production code rather than an experiment, but if the adoption question weighs heavier for you, `## Incubating` seems the fairer home and I would be glad for you to move it there — or to close this and let me come back when there is real adoption to point at.
