### PR TITLE
Add sql2erd to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This list accepts and encourages pull requests. See [CONTRIBUTING](https://githu
 - [phpMyAdmin](https://github.com/phpmyadmin/phpmyadmin) - a free software tool written in PHP, intended to handle the administration of MySQL over the Web.
 - [pspg](https://github.com/okbob/pspg) - provides a pager with enhanced visualization and navigation for tabular data. Originally implemented for PostgreSQL, but also supports MySQL.
 - [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) - a Mac database management application for working with MySQL databases.
+- [sql2erd](https://sql2erd.dev) - In-browser MySQL DDL to ERD diagram generator running client-side via WebAssembly.
 - [TablePro](https://github.com/TableProApp/TablePro) - Native macOS client for MySQL and many other databases with inline editing, SSH tunneling, and AI assistant. Free and open-source.
 - [SQLyog Community edition](https://github.com/webyog/sqlyog-community) - SQLyog Community edition. For Windows, works fine under wine in Mac and Linux
 - [squix](https://github.com/eduardofuncao/squix) - SQL command-line client with query management and interactive results.


### PR DESCRIPTION
### Description
Add [sql2erd](https://sql2erd.dev) to the GUI section.

### Details
- **Tool:** [sql2erd](https://sql2erd.dev)
- **Description:** In-browser MySQL DDL to ERD diagram generator running client-side via WebAssembly.
- **Category:** GUI (ordered alphabetically between `Sequel Ace` and `SQLyog`).
- **Access & Privacy:** Free web tool, no signup or login required. Renders MySQL schemas into interactive diagrams entirely inside the browser with zero server transmission.